### PR TITLE
docs(readme): 修复 Star History 图表链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ shorebird patch --platforms=android
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=ys1231/appproxy&type=Date)](https://star-history.com/#ys1231/appproxy&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=ys1231/appproxy&type=Date)](https://star-history.dera.page/#ys1231/appproxy&Date)
 
 # 免责声明
 - 本程序仅用于学习交流, 请勿用于非法用途.


### PR DESCRIPTION
当前 README 中的 Star History 图表已无法正常显示，原因是 GitHub 星标数据接口的限制导致原有服务失效。

本次修改将图表链接切换到可正常工作的服务地址，保证 Star History 图表能够持续展示项目星标趋势，方便用户直观了解项目热度。